### PR TITLE
Remove SFML submodule path and update README

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Rendera/libs/SFML"]
-	path = Rendera/libs/SFML
-	url = https://github.com/SFML/SFML.git
 [submodule "utilities/libs/xsimd"]
 	path = utilities/libs/xsimd
 	url = https://github.com/xtensor-stack/xsimd.git

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ This project was made as a part of the Seasons of Code (SoC) initiative by the W
 To build the project and run locally,
 
 ```bash
-    mkdir build
     cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release
     cmake --build build
     ./build/Rendera/Rendera

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ To build the project and run locally,
 
 ```bash
     mkdir build
-    cd build
-    cmake ..
-    cmake --build . config Release
+    cmake -S. -Bbuild -DCMAKE_BUILD_TYPE=Release
+    cmake --build build
+    ./build/Rendera/Rendera
 ```

--- a/README.md
+++ b/README.md
@@ -5,3 +5,19 @@ Rendera
 A raytracing engine written in C++17.
 
 This project was made as a part of the Seasons of Code (SoC) initiative by the WnCC Club at IITB.
+
+>Note: The project uses some libraries which are added as submodules. To clone this project and build locally,
+
+
+```bash
+    git clone --recurse-submodules https://github.com/wermos/Rendera.git
+```
+
+To build the project and run locally,
+
+```bash
+    mkdir build
+    cd build
+    cmake ..
+    cmake --build . config Release
+```


### PR DESCRIPTION
-SFML submodule path is removed from `.gitmodules`
-README now includes instructions to clone ad build